### PR TITLE
Add forced plugins feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ however, insignificant breaking changes do not guarantee a major version bump, s
 
 ### Added
 - Added `content_type` to attachments stored in the database.
+- Add Forced plugins. Allows auto installing un-removable plugins via `FORCED_PLUGINS` environment variable contain a comma separate list of plugins. (GH#5)
 
 ### Changed
 - Changing a threads title or NSFW status immediately updates the status in the database.

--- a/cogs/plugins.py
+++ b/cogs/plugins.py
@@ -176,9 +176,14 @@ class Plugins(commands.Cog):
             logger.debug(f"loading forced plugin {plugin_name}")
             await self._init_load_plugin(plugin_name)
 
-        logger.debug("loading config plugins")
+        user_plugins = list(self.bot.config["plugins"])
+        logger.debug(f"loading {len(user_plugins)} config plugins")
 
-        for plugin_name in list(self.bot.config["plugins"]):
+        for plugin_name in user_plugins:
+            # Skip loading this plugin if it is in the force load list and thus already loaded
+            if plugin_name in self.forced_plugins:
+                logger.debug(f"Skipped loading user plugin {plugin_name} because it is forced installed.")
+                continue
             await self._init_load_plugin(plugin_name)
 
         logger.debug("Finished loading all plugins.")


### PR DESCRIPTION
Allows the admin to force certain plugins to be installed automatically.
These are set via a comma separated list with the environment variable FORCED_PLUGINS.
They cannot be removed via commands