### PR TITLE
Add Unattended upgrade

### DIFF
--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -1957,6 +1957,15 @@ class Utility(commands.Cog):
     async def migrate(self, ctx, migration: str):
         """Perform a given database migration"""
         if migration == "blocklist":
+            if not len(self.bot.config["blocked"]) > 0 and not len(self.bot.config["blocked_roles"]) > 0:
+                await ctx.send(
+                    embed=discord.Embed(title="Error",
+                                        description="No blocked users or roles can be migrated.\n\n "
+                                                    "You don't need to migrated the blocklist as it's "
+                                                    "already been done or there is nothing to migrate.",
+                                        color=self.bot.error_color)
+                )
+                return
             try:
                 await migrations.migrate_blocklist(self.bot)
             except Exception as e:


### PR DESCRIPTION

Adds `UNATTENDED_MIGRATION` environment variable, which, when enabled, automatically runs migrations.

Currently only applies to the blocklist migrations (only existing migration)